### PR TITLE
Fix SIGSEGV on Linux caused by HashValue(Am_Input_Char, int)

### DIFF
--- a/src/opal/text_functions.cpp
+++ b/src/opal/text_functions.cpp
@@ -857,12 +857,13 @@ HashValue(Am_Input_Char key, int size)
 {
   // Look only at the code, button_down, shift, control, meta,
   // click_count fields.  any_modifier is ignored.
-  return ((((((unsigned long)key.code << (1 + (unsigned long)key.shift))
+  int hash = (((((unsigned long)key.code
+             << (1 + (unsigned long)key.shift))
              << (1 + (unsigned long)key.control))
-            << (1 + (unsigned long)key.meta))
-           << (3 + (unsigned long)key.button_down))
-          << (4 + (unsigned long)key.click_count) %
-         size);
+             << (1 + (unsigned long)key.meta))
+             << (3 + (unsigned long)key.button_down))
+             << (4 + (unsigned long)key.click_count);
+  return hash % size;
 }
 
 int


### PR DESCRIPTION
Running on Linux (Fedora 24, Kernel 4.7.3 x86_64), all samples crash with SIGSEGV. Example backtrace (in this case it's tree, but it's the same for all samples)

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7a45eae in Am_Map_in_char2text_op::FindAssoc (this=0x6657f0, key=...) at ../src/opal/text_functions.cpp:877
877 AM_IMPL_MAP(in_char2text_op, Am_Input_Char, Am_Input_Char(-1),
Missing separate debuginfos, use: dnf debuginfo-install libSM-1.2.2-4.fc24.x86_64 libgcc-6.1.1-3.fc24.x86_64 libstdc++-6.1.1-3.fc24.x86_64
(gdb) bt
#0  0x00007ffff7a45eae in Am_Map_in_char2text_op::FindAssoc (this=0x6657f0, key=...) at ../src/opal/text_functions.cpp:877
#1  0x00007ffff7a45a65 in Am_Map_in_char2text_op::SetAt (this=0x6657f0, key=..., item=0x7ffff7a41f05 <Am_Move_Cursor_Right(Am_Object)>)
    at ../src/opal/text_functions.cpp:877
#2  0x00007ffff7a46e64 in Am_Edit_Translation_Table_Data::Add (this=0x665670, ic=..., func=0x7ffff7a41f05 <Am_Move_Cursor_Right(Am_Object)>)
    at ../src/opal/text_functions.cpp:981
#3  0x00007ffff7a46ca6 in Am_Edit_Translation_Table::Add (this=0x7fffffffdcc0, ic=..., func=0x7ffff7a41f05 <Am_Move_Cursor_Right(Am_Object)>)
    at ../src/opal/text_functions.cpp:965
#4  0x00007ffff7a467ed in Am_Edit_Translation_Table::Default_Table () at ../src/opal/text_functions.cpp:925
#5  0x00007ffff7a0dd6b in init () at ../src/inter/inter_text.cpp:621
#6  0x00007ffff7ac24e1 in Am_Initializer::Do_Initialize () at ../src/utils/initializer.cpp:68
#7  0x00007ffff7a3a4d7 in Am_Initialize () at ../src/opal/opal.cpp:193
#8  0x0000000000404c5e in main () at ../samples/tree.cpp:232
(gdb) 

```

I then add a breakpoint inside `Am_Map_in_char2text_op::FindAssoc`:

```
(gdb) print m_table
$1 = (Am_Assoc_in_char2text_op **) 0x66a8f0
(gdb) print hash
$2 = 325632
(gdb) print m_size
$3 = 53
(gdb) print key
$4 = {code = 318, shift = false, control = false, meta = false, 
  any_modifier = false, button_down = Am_NEITHER, 
  click_count = Am_NOT_MOUSE, static Am_Input_Char_ID = 16889}

```

The problem is in HashValue, so I changed it by casting the value of the shifts to int.
